### PR TITLE
some corrections and a little refactoring of the activemq.xml template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ActiveMQ Ansible Role  
 =====================
 
-Installs ActiveMQ 
+Installs ActiveMQ
 
 Build Status:
 -------------
@@ -9,11 +9,11 @@ Currently only supports Ansible lint, need to add distributions (work started in
 
 [![Build Status](https://travis-ci.org/shelleg/ansible-role-activemq.svg?branch=master)](https://travis-ci.org/shelleg/ansible-role-activemq)
 
-[![Code Climate](https://codeclimate.com/github/shelleg/ansible-role-activemq/badges/gpa.svg)](https://codeclimate.com/github/shelleg/ansible-role-activemq) [![Issue Count](https://codeclimate.com/github/shelleg/ansible-role-activemq/badges/issue_count.svg)](https://codeclimate.com/github/shelleg/ansible-role-activemq) [![Test Coverage](https://codeclimate.com/github/shelleg/ansible-role-activemq/badges/coverage.svg)](https://codeclimate.com/github/shelleg/ansible-role-activemq/coverage) 
+[![Code Climate](https://codeclimate.com/github/shelleg/ansible-role-activemq/badges/gpa.svg)](https://codeclimate.com/github/shelleg/ansible-role-activemq) [![Issue Count](https://codeclimate.com/github/shelleg/ansible-role-activemq/badges/issue_count.svg)](https://codeclimate.com/github/shelleg/ansible-role-activemq) [![Test Coverage](https://codeclimate.com/github/shelleg/ansible-role-activemq/badges/coverage.svg)](https://codeclimate.com/github/shelleg/ansible-role-activemq/coverage)
 
 Requirements
 ------------
-JAVA Oracle
+JAVA (i.e. openjdk 1.8 jre)
 
 Role Variables
 --------------
@@ -24,17 +24,20 @@ Default installation mode for Rhel/Centos:
 User & Group activemq runs under:
 * `amq_user:   activemq`
 * `amq_group:  activemq`
-* `amq_home_dir:  /var/lib/activemq`
-* `amq_log_dir: /var/log/activemq`
+* `amq_home_dir:  /var/lib/{{ amq_user }}`
+* `amq_log_dir: /var/log/{{ amq_user }}`
 
 Installation directory:
 * `amq_install_dir: /opt`
-* `amq_run_dir: "/opt/{{ amq_user }}"`
+* `amq_run_dir: "{{ amq_install_dir }}/{{ amq_user }}"`
+
+ActiveMQ configuration:
+* `amq_conf_dir: "{{ amq_install_dir }}/activemq/conf"`
 
 Default version:
 * `amq_version_major: "5"`
-* `amq_version_minor: "13"`
-* `amq_version_patch: "3"`
+* `amq_version_minor: "15"`
+* `amq_version_patch: "8"`
 * `amq_version: "{{ amq_version_major }}.{{ amq_version_minor }}.{{amq_version_patch }}"`
 
 Download url - this can be overwritten with your corporate url prefix:
@@ -48,6 +51,34 @@ amq_env_vars:
   ACTIVEMQ_BASE: "{{ amq_run_dir }}"
 ```
 
+Custrom broker xml config template
+* `amq_custom_xml_config: True`
+* `amq_custom_xml_config_path: "activemq.xml.j2"`
+
+Custom log4j.properties template
+* `amq_custom_log4j_config: True`
+* `amq_custom_log4j_config_path: "log4j.properties.j2"`
+
+activemq.xml.j2 template variables
+* `amq_broker_name: "{{ ansible_hostname }}"`
+* `amq_admin_user: admin`
+* `amq_admin_password: "{{ amq_admin_user }}"`
+* `amq_authentication: false`
+
+transport connectors in the activemq.xml.j2 template
+* `amq_openwire_transport_connector_uri: "tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"`
+* `amq_amqp_transport_connector_uri: "amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"`
+* `amq_stomp_transport_connector_uri: "stomp://0.0.0.0:61713?transport.closeAsync=false"`
+* `amq_stomp_and_nio_transport_connector_uri: "stomp+nio://0.0.0.0:61712?transport.closeAsync=false"`
+
+active transport connectors in the activemq.xml.j2 template:
+```
+amq_transport_connectors:
+   openwire: "{{ amq_openwire_transport_connector_uri }}"
+   amqp : "{{ amq_amqp_transport_connector_uri }}"
+   stomp : "{{ amq_stomp_transport_connector_uri }}"
+   "stomp+nio" : "{{ amq_stomp_and_nio_transport_connector_uri }}"
+```
 Dependencies
 ------------
 Requires Java in order to run.
@@ -58,6 +89,9 @@ Example Playbook
 ----------------
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+Simple playbook:
+
 ``` shell
 
 ---
@@ -68,12 +102,58 @@ Including an example of how to use your role (for instance, with variables passe
     - ansible-role-activemq
 ```
 
+Little more advanced:
+
+``` shell
+---
+- hosts: all
+  become: yes
+  vars:
+    java_packages: java-1.8.0-openjdk
+    amq_user: activemq
+    amq_version_major: "5"
+    amq_version_minor: "15"
+    amq_version_patch: "8"
+
+    amq_env_vars:
+       ACTIVEMQ_PROCESS: "activemq"
+       ACTIVEMQ_OPTS: "-Djava.net.preferIPv4Stack=true"
+       ACTIVEMQ_OPTS_MEMORY: "-Xms512m -Xmx512m"
+       ACTIVEMQ_PIDDIR: "/var/run/activemq"
+       ACTIVEMQ_PIDFILE: "${ACTIVEMQ_PIDDIR}/activemq.pid"
+
+    # just 1 connector not all defaults....
+    amq_transport_connectors:
+       openwire: "{{ amq_openwire_transport_connector_uri }}"
+
+
+  tasks:
+    - name: java
+      include_role:
+        name: geerlingguy.java
+
+    - name: ActiveMQ
+      include_role:
+        name: activemq
+        public: yes
+    - debug:
+        var: amq_run_dir
+```
 Changelog:
 ----------
 
 * initial release - initial release support ubutnu 14/16.04 && centos 6/7
-* [v1.0.0](https://github.com/shelleg/ansible-role-activemq/releases)          - Add support for systemd in centos7 
+* [v1.0.0](https://github.com/shelleg/ansible-role-activemq/releases)          - Add support for systemd in centos7
 * [v1.0.1](https://github.com/shelleg/ansible-role-activemq/releases)          - Add support for centos6 (no systemd)
+* [vx.x.x]
+ - renamed variables starting with activemq_ to amq_ to be more consistent with previous version(s)
+ - changed activemq_instance_name to amq_broker_name to be more consistent with the .xml file.
+ - added a custom log4j.properties template
+ - added default username/password to activemq broker config
+ - changed the build up of the amq_transport connectors in the activemq.xml.j2 template to be more flexible
+ - bumped default versdion to 5.15.8
+ - added custom log4j.properties
+
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,10 @@
 amq_user: activemq
 amq_group:  activemq
 amq_install_dir: /opt
-activemq_conf_dir: '{{ activemq_install_dir }}/activemq/conf'
-amq_run_dir: "/opt/{{ amq_user }}"
-amq_home_dir:  /var/lib/activemq
-amq_log_dir: /var/log/activemq
+amq_conf_dir: "{{ amq_install_dir }}/activemq/conf"
+amq_run_dir: "{{ amq_install_dir }}/{{ amq_user }}"
+amq_home_dir:  /var/lib/{{ amq_user }}
+amq_log_dir: /var/log/{{ amq_user }}
 
 # default installation mode
 amq_install_mode: tarball
@@ -16,8 +16,8 @@ amq_url_prefix: "http://archive.apache.org/dist/activemq/"
 
 # calculate version
 amq_version_major: "5"
-amq_version_minor: "13"
-amq_version_patch: "3"
+amq_version_minor: "15"
+amq_version_patch: "8"
 
 amq_version: "{{ amq_version_major }}.{{ amq_version_minor }}.{{ amq_version_patch }}"
 
@@ -32,11 +32,28 @@ amq_env_vars:
   ACTIVEMQ_BASE: "{{ amq_run_dir }}"
 
 # Use custom broker xml config
-activemq_custom_xml_config: True
-activemq_custom_xml_config_path: 'activemq.xml.j2'
+amq_custom_xml_config: True
+amq_custom_xml_config_path: "activemq.xml.j2"
+# Use custom log4j.properties
+amq_custom_log4j_config: True
+amq_custom_log4j_config_path: "log4j.properties.j2"
 
 # activemq broker config
-activemq_openwire_transport_connector_uri: 'tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600'
-activemq_amqp_transport_connector_uri: 'amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600'
-activemq_stomp_transport_connector_uri: 'stomp://0.0.0.0:61713?transport.closeAsync=false'
-activemq_stomp_and_nio_transport_connector_uri: 'stomp+nio://0.0.0.0:61712?transport.closeAsync=false'
+amq_broker_name: "{{ ansible_hostname }}"
+amq_admin_user: admin
+amq_admin_password: "{{ amq_admin_user }}"
+amq_authentication: false
+
+
+  
+amq_openwire_transport_connector_uri: "tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"
+amq_amqp_transport_connector_uri: "amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"
+amq_stomp_transport_connector_uri: "stomp://0.0.0.0:61713?transport.closeAsync=false"
+amq_stomp_and_nio_transport_connector_uri: "stomp+nio://0.0.0.0:61712?transport.closeAsync=false"
+
+amq_transport_connectors:
+   openwire: "{{ amq_openwire_transport_connector_uri }}"
+   amqp : "{{ amq_amqp_transport_connector_uri }}"
+   stomp : "{{ amq_stomp_transport_connector_uri }}"
+   "stomp+nio" : "{{ amq_stomp_and_nio_transport_connector_uri }}"
+

--- a/tasks/tarball.yml
+++ b/tasks/tarball.yml
@@ -1,25 +1,25 @@
 ---
 
-- name: "determin if to use systemd or not (for centos 6 support)"
+- name: "determine if to use systemd or not (for centos 6 support)"
   stat:
     path: /etc/systemd
   register: systemd
 
 - debug: var=systemd.stat
 
-- name: "set fact if systemd is avail"
+- name: "set fact if systemd is available"
   set_fact:
     amq_systemd: true
   when: systemd.stat.exists
 
-- name: "Add Activemq group"
+- name: "Add ActiveMQ group"
   group:
     name: "{{ amq_group }}"
   tags:
     - init
     - group
 
-- name: "Add Activemq user"
+- name: "Add ActiveMQ user"
   user:
     name: "{{ amq_user }}"
     group: "{{ amq_group }}"
@@ -57,33 +57,14 @@
 #   when: amq_skip_checksum == false and amq_checksum is defined
 #   tags: 
 #     - getbin
-
-- name: "Get tarball"
-  get_url:
-    url: "{{ amq_url }}"
-    dest: "/tmp/apache-activemq-{{ amq_version }}-bin.tar.gz"
+- name: "download and unpackage Apache ActiveMQ {{ amq_version }}"
+  unarchive:
+    src: "{{ amq_url }}"
+    remote_src: yes
+    dest: "{{ amq_install_dir }}"
     owner: "{{ amq_user }}"
     group: "{{ amq_group }}"
-  when: amq_skip_checksum
-  #and amq_checksum is not defined
-  tags:
-    - getbin
-
-- name: "Extract tarball" # see: https://github.com/ansible/ansible/issues/16078
-# bug in snsible >= 2.1.0.0
-#  unarchive:
-#       src=/tmp/apache-activemq-{{ amq_version }}-bin.bz2
-#       dest="{{ amq_install_dir}}"
-#       list_files=true
-#       copy=no
-#       owner={{ amq_user }}
-#       group={{ amq_group }}
-  command: tar zxvf /tmp/apache-activemq-{{ amq_version }}-bin.tar.gz --directory /opt/
-
-- name: "Become didn't work ... so chown it is ..."
-  command: chown "{{ amq_user }}"."{{ amq_user }}" /opt/apache-activemq-"{{ amq_version }}" -R
-  tags:
-    - chown
+    creates: "{{ amq_install_dir }}/apache-activemq-{{ amq_version }}"
 
 # when we upgrade activemq we might want to keep the older versions copy for just in case ...
 - name: "Create link activemq to /opt/activemq"
@@ -96,17 +77,39 @@
   tags:
     - link
 
+- name: "make activemq directories owned by {{ amq_user }}"
+  file:
+    path: "{{ item }}"
+    owner: "{{ amq_user }}"
+    group: "{{ amq_group }}"
+    state: directory
+    mode: "u=rwx,g=rx,o=rx"
+    recurse: yes
+  with_items:
+    - "{{ amq_run_dir }}"
+    - "{{ amq_log_dir }}"
+
 - name: Copy custom activemq.xml config file
   template:
-    src: '{{ activemq_custom_xml_config_path }}'
-    dest: '{{ activemq_conf_dir }}/activemq.xml'
+    src: '{{ amq_custom_xml_config_path }}'
+    dest: '{{ amq_conf_dir }}/activemq.xml'
     owner: '{{ amq_user }}'
-    group: "{{ amq_group }}"
+    group: '{{ amq_group }}'
     mode: 0644
   when:
-    - activemq_custom_xml_config == True
+    - amq_custom_xml_config == True
 
-- name: "Create init sctipt link file"
+- name: Copy custom log4j.properties file
+  template:
+    src: '{{ amq_custom_log4j_config_path }}'
+    dest: '{{ amq_conf_dir }}/log4j.properties'
+    owner: '{{ amq_user }}'
+    group: '{{ amq_group }}'
+    mode: 0644
+  when:
+    - amq_custom_log4j_config == True
+
+- name: "Create init script link file"
   file:
     src: "{{ amq_install_dir }}/activemq/bin/linux-x86-{{ ansible_userspace_bits }}/activemq"
     dest: "/etc/init.d/activemq"
@@ -115,7 +118,7 @@
     state: link
   when: amq_systemd is not defined
 
-- name: "Create init sctipt link file"
+- name: "Create init script link file"
   file:
     src: "{{ amq_install_dir }}/activemq/bin/linux-x86-{{ ansible_userspace_bits }}/activemq"
     dest: "/etc/init.d/activemq"
@@ -123,14 +126,6 @@
     group: root
     state: link
   when: amq_systemd is not defined
-
-- name: "Generate empty log file ..."
-  file:
-    path: "{{ amq_log_dir }}"
-    state: touch
-    mode: "u=rw,g=r,o=r"
-    owner: root
-    group: root
 
 - name: "Generate /etc/sysconfig/activemq Redhat"
   template:

--- a/templates/activemq.xml.j2
+++ b/templates/activemq.xml.j2
@@ -12,14 +12,14 @@
         </property>
     </bean>
 
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="{{ activemq_instance_name }}" dataDirectory="${activemq.data}">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="{{ amq_broker_name }}" dataDirectory="${activemq.data}">
         <plugins>
             <simpleAuthenticationPlugin>
               <users>
-                <authenticationUser username="{{ activemq_admin_user }}" password="{{ activemq_admin_password }}" groups="admins"/>
+                <authenticationUser username="{{ amq_admin_user }}" password="{{ amq_admin_password }}" groups="admins"/>
 
-            {% if activemq_authentication %}
-              {% for item in activemq_authentication %}
+            {% if amq_authentication %}
+              {% for item in amq_authentication %}
                 <authenticationUser username="{{ item.username }}" password="{{ item.password }}" groups="{{ item.groups }}"/>
               {% endfor %}
             {% endif %}
@@ -32,13 +32,13 @@
                   <authorizationEntries>
                     <authorizationEntry queue=">" write="admins" read="admins" admin="admins" />
                     <authorizationEntry topic=">" write="admins" read="admins" admin="admins" />
-                {% if activemq_authorization_queue is defined %}
-                  {% for item in activemq_authorization_queue %}
+                {% if amq_authorization_queue is defined %}
+                  {% for item in amq_authorization_queue %}
                       <authorizationEntry queue="{{ item.queue }}" write="{{ item.write }}" read="{{ item.read }}" admin="{{ item.admin }}" />
                   {% endfor %}
                 {% endif %}
-                {% if activemq_authorization_topic is defined %}
-                  {% for item in activemq_authorization_topic %}
+                {% if amq_authorization_topic is defined %}
+                  {% for item in amq_authorization_topic %}
                       <authorizationEntry topic="{{ item.topic }}" write="{{ item.write }}" read="{{ item.read }}" admin="{{ item.admin }}" />
                   {% endfor %}
                 {% endif %}
@@ -93,10 +93,9 @@
         </systemUsage>
 
         <transportConnectors>
-            <transportConnector name="openwire" uri="{{ activemq_openwire_transport_connector_uri }}"/>
-            <transportConnector name="amqp" uri="{{ activemq_amqp_transport_connector_uri }}"/>
-            <transportConnector name="stomp" uri="{{ activemq_stomp_transport_connector_uri }}"/>
-            <transportConnector name="stomp+nio" uri="{{ activemq_stomp_and_nio_transport_connector_uri }}"/>
+            {% for key in amq_transport_connectors %}
+            <transportConnector name="{{ key }}" uri="{{ amq_transport_connectors[key] }}"/>
+            {% endfor %}
         </transportConnectors>
 
         <shutdownHooks>

--- a/templates/log4j.properties.j2
+++ b/templates/log4j.properties.j2
@@ -1,0 +1,78 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# This file controls most of the logging in ActiveMQ which is mainly based around
+# the commons logging API.
+#
+log4j.rootLogger=INFO, console, logfile
+log4j.logger.org.apache.activemq.spring=WARN
+log4j.logger.org.apache.activemq.web.handler=WARN
+log4j.logger.org.springframework=WARN
+log4j.logger.org.apache.xbean=WARN
+log4j.logger.org.apache.camel=INFO
+log4j.logger.org.eclipse.jetty=WARN
+
+# When debugging or reporting problems to the ActiveMQ team,
+# comment out the above lines and uncomment the next.
+
+#log4j.rootLogger=DEBUG, logfile, console
+
+# Or for more fine grained debug logging uncomment one of these
+#log4j.logger.org.apache.activemq=DEBUG
+#log4j.logger.org.apache.camel=DEBUG
+
+# Console appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%5p | %m%n
+log4j.appender.console.threshold=INFO
+
+# File appender
+log4j.appender.logfile=org.apache.log4j.RollingFileAppender
+log4j.appender.logfile.file={{ amq_log_dir }}/activemq.log
+log4j.appender.logfile.maxFileSize=1024KB
+log4j.appender.logfile.maxBackupIndex=5
+log4j.appender.logfile.append=true
+log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
+log4j.appender.logfile.layout.ConversionPattern=%d | %-5p | %m | %c | %t%n
+# use some of the following patterns to see MDC logging data
+#
+# %X{activemq.broker}
+# %X{activemq.connector}
+# %X{activemq.destination}
+#
+# e.g.
+#
+# log4j.appender.logfile.layout.ConversionPattern=%d | %-20.20X{activemq.connector} | %-5p | %m | %c | %t%n
+
+log4j.throwableRenderer=org.apache.log4j.EnhancedThrowableRenderer
+
+###########
+# Audit log
+###########
+
+log4j.additivity.org.apache.activemq.audit=false
+log4j.logger.org.apache.activemq.audit=INFO, audit
+
+log4j.appender.audit=org.apache.log4j.RollingFileAppender
+log4j.appender.audit.file=${activemq.data}/audit.log
+log4j.appender.audit.maxFileSize=1024KB
+log4j.appender.audit.maxBackupIndex=5
+log4j.appender.audit.append=true
+log4j.appender.audit.layout=org.apache.log4j.PatternLayout
+log4j.appender.audit.layout.ConversionPattern=%-5p | %m | %t%n


### PR DESCRIPTION
modifications:

defaults/main.yml

- renamed variables starting with activemq_ to amq_ to be more consistent with previous version(s)
- added a custom log4j.properties template
- added default username/password to activemq broker config 
- changed the build up of the amq_transport connectors in the activemq.xml.j2 template to be more flexible
- bumped default versdion to 5.15.8

tasks/tarbal.yml
- noted some typo's in name: blocks, corrected them and might have introduced new typo's xD
- getting the tarball with ansible: unarchive instead of get_url
- no need to generate 'empty log file', just make sure the directory is owned by {{ amq_user }}

activemq.xml.j2

- changed activemq_instance_name to amq_broker_name to be more consistent with the .xml file.
  (and the previous change of renaming activemq_ to amq_ in all variables)
- building up the <transportConnectors> in a similar way as the {{ amq_env_vars }} are used

- custom log4j.properties file
  made it possible to change to 'default' logfile location to: {{ amq_log_dir }}/activemq.log